### PR TITLE
Replace Parser::getFunctionLang() with ::getTargetLanguage()

### DIFF
--- a/includes/LatestDiscussions.class.php
+++ b/includes/LatestDiscussions.class.php
@@ -176,7 +176,7 @@ class LatestDiscussions {
 					$commentFormatedDate = $commentTime->getRelativeTimestamp ( null, null, null, $chosenIntervals );
 				} else {
 					// parser may not be started yet, so this doens't works :
-					// $lang = self::$parser->getFunctionLang ();
+					// $lang = self::$parser->getTargetLanguage ();
 					// self::$parser->getUser ()
 					$lang = RequestContext::getMain()->getLanguage();
 					$user = RequestContext::getMain()->getUser();


### PR DESCRIPTION
Parser::getFunctionLang() is being deprecated.  These two functions
have been identical since 7df3473cfea59df53debb7a9eefffed8a7f20fb3
in MW 1.19 (2012).

Bug: T318860
